### PR TITLE
Update nightly.yaml

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/TypeScript'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Disable nightly publishes and twoslash publishes on non-Typescript branches.

The best way to get this to happen is to update your fork to match main on microsoft/Typescript. But this PR would work as well -- I opened it as a way to draw attention to the problem, since I get notified about the nightly failure every night.